### PR TITLE
[wip]: python3 conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,13 @@ For instance
 
 You'll need to install the dev requirements to run the tests:
 
-    pip install -r dev-requirements.txt
+To run the tests on CKAN >= 2.9, do:
 
-To run the tests:
+    pytest --ckan-ini=test.ini ckanext/dcat/tests
 
-    nosetests --nologcapture --ckan --with-pylons=test.ini
+To run the tests on CKAN <= 2.8, do:
+
+    nosetests --nologcapture --ckan --with-pylons=test-nose.ini ckanext/dcat/tests/nose
 
 Note that ckanext-datapackager's `test.ini` file assumes that the relative path from it
 to CKAN's `test-core.ini` file is `../ckan/test-core.ini`, i.e. that you have

--- a/ckanext/datapackager/tests/controllers/test_datapackage.py
+++ b/ckanext/datapackager/tests/controllers/test_datapackage.py
@@ -5,6 +5,7 @@ import nose.tools
 import requests_mock
 import ckanapi
 import datapackage
+import pytest
 
 import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
@@ -16,8 +17,9 @@ assert_true = nose.tools.assert_true
 assert_regexp_matches = nose.tools.assert_regexp_matches
 
 
-class TestDataPackageController(
-        custom_helpers.FunctionalTestBaseClass):
+@pytest.mark.ckan_config('ckan.plugins', 'datapackager')
+@pytest.mark.usefixtures('clean_db', 'with_plugins', 'with_request_context')
+class TestDataPackageController():
     '''Functional tests for the DataPackageController class.'''
 
     def test_download_datapackage(self):

--- a/ckanext/datapackager/tests/helpers.py
+++ b/ckanext/datapackager/tests/helpers.py
@@ -3,9 +3,8 @@
 import os
 
 import ckan.config.middleware
-import pylons.config as config
 import webtest
-
+from ckan.plugins.toolkit import config
 
 def get_csv_file(relative_path):
     csv_file = open(fixture_path(relative_path), 'rb')
@@ -17,64 +16,3 @@ def fixture_path(path):
     return os.path.abspath(path)
 
 
-def _get_test_app():
-    '''Return a webtest.TestApp for CKAN, with legacy templates disabled.
-
-    For functional tests that need to request CKAN pages or post to the API.
-    Unit tests shouldn't need this.
-
-    '''
-    config['ckan.legacy_templates'] = False
-    app = ckan.config.middleware.make_app(config['global_conf'], **config)
-    app = webtest.TestApp(app)
-    return app
-
-
-def _load_plugin(plugin):
-    '''Add the given plugin to the ckan.plugins config setting.
-
-    This is for functional tests that need the plugin to be loaded.
-    Unit tests shouldn't need this.
-
-    If the given plugin is already in the ckan.plugins setting, it won't be
-    added a second time.
-
-    :param plugin: the plugin to add, e.g. ``datastore``
-    :type plugin: string
-
-    '''
-    plugins = set(config['ckan.plugins'].strip().split())
-    plugins.add(plugin.strip())
-    config['ckan.plugins'] = ' '.join(plugins)
-
-
-class FunctionalTestBaseClass():
-    '''A base class for functional test classes to inherit from.
-
-    This handles loading the datapackager plugin and resetting the CKAN config
-    after your test class has run. It creates a webtest.TestApp at self.app for
-    your class to use to make HTTP requests to the CKAN web UI or API.
-
-    If you're overriding methods that this class provides, like setup_class()
-    and teardown_class(), make sure to use super() to call this class's methods
-    at the top of yours!
-
-    '''
-    @classmethod
-    def setup_class(cls):
-        # Make a copy of the Pylons config, so we can restore it in teardown.
-        cls.original_config = config.copy()
-        _load_plugin('datapackager')
-        cls.app = _get_test_app()
-
-    def setup(self):
-        import ckan.model as model
-        model.Session.close_all()
-        model.repo.rebuild_db()
-
-    @classmethod
-    def teardown_class(cls):
-        # Restore the Pylons config to its original values, in case any tests
-        # changed any config settings.
-        config.clear()
-        config.update(cls.original_config)

--- a/ckanext/datapackager/tests/lib/test_util.py
+++ b/ckanext/datapackager/tests/lib/test_util.py
@@ -2,6 +2,7 @@ import os
 
 import nose.tools
 import ckanapi as ckanapi
+import pytest
 
 import ckan.tests.factories as factories
 
@@ -9,8 +10,9 @@ import ckanext.datapackager.lib.util as util
 import ckanext.datapackager.tests.helpers as custom_helpers
 import ckanext.datapackager.exceptions as exceptions
 
-
-class TestResourceSchemaFieldCreate(custom_helpers.FunctionalTestBaseClass):
+@pytest.mark.ckan_config('ckan.plugins', 'datapackager')
+@pytest.mark.usefixtures('clean_db', 'with_plugins', 'with_request_context')
+class TestResourceSchemaFieldCreate():
 
     def test_get_path_to_resource_file_with_uploaded_file(self):
 

--- a/ckanext/datapackager/tests/logic/action/test_create.py
+++ b/ckanext/datapackager/tests/logic/action/test_create.py
@@ -2,9 +2,10 @@ import json
 import mock
 import nose.tools
 import tempfile
-import StringIO
+from io import StringIO
 
 import requests_mock
+import pytest
 
 import ckan.tests.helpers as helpers
 import ckanext.datapackager.tests.helpers as custom_helpers
@@ -12,7 +13,9 @@ import ckan.plugins.toolkit as toolkit
 import ckan.tests.factories as factories
 
 
-class TestPackageCreateFromDataPackage(custom_helpers.FunctionalTestBaseClass):
+@pytest.mark.ckan_config('ckan.plugins', 'datapackager')
+@pytest.mark.usefixtures('clean_db', 'with_plugins', 'with_request_context')
+class TestPackageCreateFromDataPackage():
     def test_it_requires_a_url_if_theres_no_upload_param(self):
         nose.tools.assert_raises(
             toolkit.ValidationError,

--- a/ckanext/datapackager/tests/logic/action/test_get.py
+++ b/ckanext/datapackager/tests/logic/action/test_get.py
@@ -2,15 +2,18 @@
 
 '''
 import nose.tools
+import pytest
 
 import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
-import ckanext.datapackager.tests.helpers as custom_helpers
+
 from ckan_datapackage_tools import converter
 import ckan.plugins.toolkit as toolkit
 
 
-class TestGet(custom_helpers.FunctionalTestBaseClass):
+@pytest.mark.ckan_config('ckan.plugins', 'datapackager')
+@pytest.mark.usefixtures('clean_db', 'with_plugins', 'with_request_context')
+class TestGet():
 
     def test_package_show_as_datapackage(self):
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,8 @@
 -r requirements.txt
-nose==1.3.7
+# nose==1.3.7
 ckanapi==3.5
 beautifulsoup4==4.5.1
 requests-mock==1.0.0
+httpretty==1.1.3
+pytest-ckan
+pytest-cov

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../ckan/test-core.ini
+use = config:../../src/ckan/test-core.ini
 ckan.storage_path = storage
 ckan.activity_streams_enabled = false
 


### PR DESCRIPTION
# Overview

Moves the extension to Python 3.

Tests are currently:
```
ckanext/datapackager/tests/controllers/test_datapackage.py FFFFE                                                                                                                                                                                                         [  7%]
ckanext/datapackager/tests/lib/test_converter.py ................................F........                                                                                                                                                                               [ 71%]
ckanext/datapackager/tests/lib/test_util.py F.                                                                                                                                                                                                                           [ 75%]
ckanext/datapackager/tests/logic/action/test_create.py .EFEEFEEEEEEEF                                                                                                                                                                                                    [ 96%]
ckanext/datapackager/tests/logic/action/test_get.py F.                                                                                                                                                                                                                   [100%]
```

Some remaining issues with `requests_mock` and other details. I will also move some of the `nose.tools.assert_equals` to regular python assertions.

---

Please preserve this line to notify @amercader (lead of this repository)
