### PR TITLE
Fix GitHub ci ckan 2.9

### DIFF
--- a/ckanext/datapackager/controllers/datapackage.py
+++ b/ckanext/datapackager/controllers/datapackage.py
@@ -45,7 +45,7 @@ def import_datapackage():
     _authorize_or_abort(context)
 
     try:
-        if len(toolkit.request.form.keys()) > 0:
+        if len(list(toolkit.request.form.keys())) > 0:
             params = toolkit.request.form
         else:
             params = toolkit.request.params

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-slugify==1.2.4
 datapackage==1.15.2
 six
 ckan-datapackage-tools==0.1.0
+pytest==6.0


### PR DESCRIPTION
Stick to version 6.0 of pytest to fix error with resultlog not found
